### PR TITLE
XmlCacheProvider, DirtyTrackingObject

### DIFF
--- a/src/SoundInTheory.DynamicImage/Caching/XmlCacheProvider.cs
+++ b/src/SoundInTheory.DynamicImage/Caching/XmlCacheProvider.cs
@@ -85,10 +85,10 @@ namespace SoundInTheory.DynamicImage.Caching
 
 				foreach (var dependency in dependencies)
 					dependenciesElement.Add(new XElement("dependency",
-						new XAttribute("text1", dependency.Text1),
-						new XAttribute("text2", dependency.Text2),
-						new XAttribute("text3", dependency.Text3),
-						new XAttribute("text4", dependency.Text4)));
+						new XAttribute("text1", dependency.Text1 ?? string.Empty),
+						new XAttribute("text2", dependency.Text2 ?? string.Empty),
+						new XAttribute("text3", dependency.Text3 ?? string.Empty),
+						new XAttribute("text4", dependency.Text4 ?? string.Empty)));
 
 				_doc.Root.Add(itemElement);
 				_doc.Save(_docPath);

--- a/src/SoundInTheory.DynamicImage/DirtyTrackingObject.cs
+++ b/src/SoundInTheory.DynamicImage/DirtyTrackingObject.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Text;
+using System.Collections;
 
 namespace SoundInTheory.DynamicImage
 {
@@ -50,9 +51,24 @@ namespace SoundInTheory.DynamicImage
 			foreach (var kvp in _propertyStore)
 			{
 				if (kvp.Value is IDirtyTrackingObject)
+				{
 					sb.AppendFormat("{0}: {1};", kvp.Key, ((IDirtyTrackingObject)kvp.Value).GetDirtyProperties());
+				}
 				else
-					sb.AppendFormat("{0}: {1};", kvp.Key, kvp.Value);
+				{
+					// Write each element of an array individially
+					if (kvp.Value is IEnumerable && !(kvp.Value is string))
+					{
+						sb.AppendFormat("{0}: [", kvp.Key);
+						foreach (var element in (IEnumerable)kvp.Value)
+							sb.AppendFormat("{0},", element);
+						sb.Append("]");
+					}
+					else
+					{
+						sb.AppendFormat("{0}: {1};", kvp.Key, kvp.Value);
+					}
+				}
 			}
 			sb.Append("}");
 			return sb.ToString();


### PR DESCRIPTION
I've tried to use XML caching with SQL DB as a datasource and discovered that SqlDatabaseImageSource leaves dependency.Text4 property as null. This null value wasn't checked in XmlCacheProvider and thus lead to exception.

Another problem was related to cache key generation. DirtyTrackingObject is calling default .ToString() method on arrays and the resulting key looks like this: "System.String[]". I've added some code that iterates through the array elements and calls ToString() on elements.
