### PR TITLE
Fix memory leak in LayerBlender

### DIFF
--- a/src/SoundInTheory.DynamicImage/LayerBlender.cs
+++ b/src/SoundInTheory.DynamicImage/LayerBlender.cs
@@ -27,24 +27,27 @@ namespace SoundInTheory.DynamicImage
 
 			foreach (Layer layer in layers)
 			{
-				dv.Effect = new LayerBlenderEffect(layer.BlendMode, output.Width, output.Height)
+				using (var effect = new LayerBlenderEffect(layer.BlendMode, output.Width, output.Height)
 				{
 					Background = new ImageBrush(imageSource)
 					{
 						TileMode = TileMode.None,
 						Stretch = Stretch.None,
-						ViewportUnits  = BrushMappingMode.RelativeToBoundingBox,
+						ViewportUnits = BrushMappingMode.RelativeToBoundingBox,
 						Viewport = new System.Windows.Rect(0, 0, 1, 1)
 					}
-				};
+				})
+				{
+					dv.Effect = effect;
+					DrawingContext dc = dv.RenderOpen();
+					dc.PushTransform(new TranslateTransform(layer.X + layer.Padding.Left, layer.Y + layer.Padding.Top));
+					dc.DrawImage(layer.Bitmap.InnerBitmap, new System.Windows.Rect(0, 0, layer.Bitmap.Width, layer.Bitmap.Height));
+					dc.Pop();
+					dc.Close();
 
-				DrawingContext dc = dv.RenderOpen();
-				dc.PushTransform(new TranslateTransform(layer.X + layer.Padding.Left, layer.Y + layer.Padding.Top));
-				dc.DrawImage(layer.Bitmap.InnerBitmap, new System.Windows.Rect(0, 0, layer.Bitmap.Width, layer.Bitmap.Height));
-				dc.Pop();
-				dc.Close();
+					rtb.Render(dv);
+				}
 
-				rtb.Render(dv);
 				imageSource = rtb;
 			}
 

--- a/src/SoundInTheory.DynamicImage/ShaderEffects/LayerBlending/LayerBlenderEffect.cs
+++ b/src/SoundInTheory.DynamicImage/ShaderEffects/LayerBlending/LayerBlenderEffect.cs
@@ -8,7 +8,7 @@ using SoundInTheory.DynamicImage.Util;
 
 namespace SoundInTheory.DynamicImage.ShaderEffects.LayerBlending
 {
-	internal class LayerBlenderEffect : ShaderEffect
+	internal class LayerBlenderEffect : ShaderEffect, IDisposable
 	{
 		private const int RandomSize = 512;
 
@@ -90,6 +90,11 @@ namespace SoundInTheory.DynamicImage.ShaderEffects.LayerBlending
 				});
 				UpdateShaderValue(RandomBrushProperty);
 			}
+		}
+
+		void IDisposable.Dispose()
+		{
+			PixelShader = null;
 		}
 	}
 }


### PR DESCRIPTION
Setting the PixelShader in the LayerBlender seems to cause a short-term but rapid leak of unmanaged memory under heavy use.

Adding a disposer which nulls the PixelShader property appears to fix the problem.
